### PR TITLE
DB modification: Add mobile phone number to user_real_names table for SMS identifications

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,5 +27,5 @@
 # Ignore master key for decrypting credentials and more.
 /config/master.key
 /config/secrets.yml
-
+/.env
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -49,13 +49,14 @@ Things you may want to cover:
 - belongs_to_active_hash :prefecture
 - belongs_to :user
 
-## user_real_names table
+## user_identifications table
 |Column|Type|Options|
 |------|----|-------|
 |last_name|string|null: false, limit: 40|
 |first_name|string|null: false, limit: 40|
 |last_name_kana|string|null: false, limit: 40|
 |first_name_kana|string|null: false, limit: 40|
+|mobile_phone_number|integer|null: false, limit: 5|
 |user|references|null: false, foreign_key: true|
 ### Association
 - belongs_to :user


### PR DESCRIPTION
# what
SMS認証において携帯電話番号を保存して認証番号を送付し、本人確認を行うために必要なテーブルを追加。

# why
SMS認証を行うに当たって、携帯電話番号を保存して送付する仕組みであるため。