### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,17 +84,17 @@ Things you may want to cover:
 |------|----|-------|
 |name|string|null: false, limit: 80|
 |detail|text|null: false|
-|condition|string|null: false, limit: 20|
+|condition_id|integer|null: false|
 |price|integer|null: false|
 |seller|references|null: false, foreign_key: {to_table: users}|
 |buyer|references|null: false, foreign_key: {to_table: users}|
 |is_seller_shipping|boolean|null: false, default: true|
-|prefecture|references|null: false, foreign_key: true|
-|shipping_period|references|null: false, foreign_key: true|
-|shipping_method|references|null: false, foreign_key: true|
+|prefecture_id|integer|null: false|
+|shipping_period_id|integer|null: false|
+|shipping_method_id|integer|null: false|
 |brand|references|foreign_key: true|
 |category|references|null: false, foreign_key: true|
-|item_status|references|null: false, foreign_key: true|
+|item_status_id|integer|null: false|
 ### Associations
 - belongs_to :user
 - has_many :images

--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ Things you may want to cover:
 - belongs_to :brand
 - belongs_to :category
 - has_many :dealing_comments
+- belongs_to_active_hash :condition
 - belongs_to_active_hash :prefecture
 - belongs_to_active_hash :shipping_period
 - belongs_to_active_hash :shipping_method


### PR DESCRIPTION
## What
itemテーブルのうち、active_hashを使う項目のデータ型・カラム名を変更（condition, prefecture, shipping_period, shipping_method, item_status）
- 

## Why
active_hashを使用する情報はactive_recordテーブルが作成されていないため、references型での連携ができないためデータ型を変更して活用するため。