### PR TITLE
ログイン・ログアウトの挙動の修正

### DIFF
--- a/app/views/homes/_header-login.html.haml
+++ b/app/views/homes/_header-login.html.haml
@@ -15,15 +15,15 @@
     .header__bottom--right
       %ul.header-list
         %li.header-list__box
-          = link_to root_path , class: "header-list__box--text" do
+          = link_to mypages_path , class: "header-list__box--text" do
             %i.far.fa-heart
             %p いいね! 一覧
         %li.header-list__box
-          = link_to root_path , class: "header-list__box--text" do
+          = link_to mypages_path , class: "header-list__box--text" do
             %i.far.fa-bell
             %p お知らせ
         %li.header-list__box
-          = link_to root_path , class: "header-list__box--text" do
+          = link_to mypages_path , class: "header-list__box--text" do
             %i.fas.fa-check
             %p やることリスト
         %li.header-list__box

--- a/app/views/items/index.html.haml
+++ b/app/views/items/index.html.haml
@@ -1,4 +1,7 @@
 .wrapper
-  = render partial: 'homes/header'
+  - if user_signed_in?
+    = render partial: 'homes/header-login'
+  - else
+    = render partial: 'homes/header'
   = render partial: 'homes/contents'
   = render partial: 'homes/footer'

--- a/app/views/mypages/logout.html.haml
+++ b/app/views/mypages/logout.html.haml
@@ -10,7 +10,7 @@
     = render partial: 'homes/btn-exhibit'
     .user-logout
       .user-logout__button
-        = link_to destroy_user_session_path do
+        = link_to destroy_user_session_path, method: :delete do
           .btn-logout
             ログアウト
   = render partial: 'homes/footer'


### PR DESCRIPTION
## what
- ログイン時に新規登録、ログインボタンを表示せずマイページへのリンクを表示するように修正
- ログアウト機能のリンクのhttpメソッドをgetからdeleteに指定し修正

## why
正しいリンクを生成するため。エラーを解消するため。