### PR TITLE
ユーザー登録、ログインに関する制御の追加（ログイン必須ページ、タイムアウト）

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,6 @@
 class ApplicationController < ActionController::Base
   before_action :basic_auth, if: :production?
+  before_action :store_current_location, unless: :devise_controller?
   protect_from_forgery with: :exception
 
   private
@@ -12,5 +13,9 @@ class ApplicationController < ActionController::Base
     authenticate_or_request_with_http_basic do |username, password|
       username == ENV["BASIC_AUTH_USER"] && password == ENV["BASIC_AUTH_PASSWORD"]
     end
+  end
+
+  def store_current_location
+    store_location_for(:user, request.url)
   end
 end

--- a/app/controllers/buy_controller.rb
+++ b/app/controllers/buy_controller.rb
@@ -1,7 +1,9 @@
 class BuyController < ApplicationController
   require 'payjp'
+  include ApplicationHelper
   include PaymentsHelper
   include ItemHelper
+  before_action :redirect_to_login
 
   def show
     @item = Item.find(params[:id])

--- a/app/controllers/buy_controller.rb
+++ b/app/controllers/buy_controller.rb
@@ -4,18 +4,15 @@ class BuyController < ApplicationController
   include PaymentsHelper
   include ItemHelper
   before_action :redirect_to_login
+  before_action :set_user_info
 
   def show
     @item = Item.find(params[:id])
-    @delivery = current_user.user_delivery
-    @payment = UserPayment.where(user_id: current_user.id).first
     get_card_info
   end
 
   def create
     @item = Item.find(item_id)
-    @payment = UserPayment.where(user_id: current_user.id).first
-    @delivery = current_user.user_delivery
     get_card_info
     if @item.item_status_id == 3
       @errors = "出品停止中の商品です"
@@ -53,7 +50,7 @@ class BuyController < ApplicationController
       @errors = "エラーが発生しました"
       return_to_show
     end
-end
+  end
 
   private
 
@@ -84,4 +81,8 @@ end
     }
   end
 
+  def set_user_info
+    @delivery = UserDelivery.where(user_id: current_user.id).first
+    @payment = UserPayment.where(user_id: current_user.id).first
+  end
 end

--- a/app/controllers/deliveries_controller.rb
+++ b/app/controllers/deliveries_controller.rb
@@ -1,6 +1,8 @@
 class DeliveriesController < ApplicationController
   include ApplicationHelper
+  before_action :redirect_to_root, only: [:new, :create]
   before_action :redirect_to_login, only: [:show, :update]
+
   def new
     @user_delivery = UserDelivery.new
   end
@@ -28,6 +30,10 @@ class DeliveriesController < ApplicationController
   end
 
   protected
+
+  def redirect_to_root
+    redirect_to root_path unless session[:user_registration?]
+  end
 
   def user_delivery_params
     params.require(:user_delivery).permit(:last_name, :first_name, :last_name_kana, :first_name_kana, :postal_number, :prefecture_id, :city, :block, :building_name, :phone_number).merge(user_id: current_user.id)

--- a/app/controllers/deliveries_controller.rb
+++ b/app/controllers/deliveries_controller.rb
@@ -31,10 +31,6 @@ class DeliveriesController < ApplicationController
 
   protected
 
-  def redirect_to_root
-    redirect_to root_path unless session[:user_registration?]
-  end
-
   def user_delivery_params
     params.require(:user_delivery).permit(:last_name, :first_name, :last_name_kana, :first_name_kana, :postal_number, :prefecture_id, :city, :block, :building_name, :phone_number).merge(user_id: current_user.id)
   end

--- a/app/controllers/deliveries_controller.rb
+++ b/app/controllers/deliveries_controller.rb
@@ -1,4 +1,6 @@
 class DeliveriesController < ApplicationController
+  include ApplicationHelper
+  before_action :redirect_to_login, only: [:show, :update]
   def new
     @user_delivery = UserDelivery.new
   end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,7 @@
 class ItemsController < ApplicationController
   include ItemHelper
+  include ApplicationHelper
+  before_action :redirect_to_login, except: [:index, :show]
   def index
     @items = Item.includes(:images).order(id: 'DESC').limit(10)
   end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,6 +2,7 @@ class ItemsController < ApplicationController
   include ItemHelper
   include ApplicationHelper
   before_action :redirect_to_login, except: [:index, :show]
+
   def index
     @items = Item.includes(:images).order(id: 'DESC').limit(10)
   end
@@ -83,7 +84,7 @@ class ItemsController < ApplicationController
       respond_to do |format| 
         format.js { render alert_text }
       end
-    end    
+    end
   end
   
   def item_params

--- a/app/controllers/likes_controller.rb
+++ b/app/controllers/likes_controller.rb
@@ -1,6 +1,8 @@
 class LikesController < ApplicationController
 
+  include ApplicationHelper
   before_action :item_setting
+  before_action :redirect_to_login
 
   def create
     @like = current_user.likes.new(item_id: params[:item_id])

--- a/app/controllers/likes_controller.rb
+++ b/app/controllers/likes_controller.rb
@@ -1,5 +1,4 @@
 class LikesController < ApplicationController
-
   include ApplicationHelper
   before_action :item_setting
   before_action :redirect_to_login
@@ -38,5 +37,4 @@ class LikesController < ApplicationController
   def return_error
     @likes_count = "err"
   end
-
 end

--- a/app/controllers/mypages_controller.rb
+++ b/app/controllers/mypages_controller.rb
@@ -1,4 +1,6 @@
 class MypagesController < ApplicationController
+  include ApplicationHelper
+  before_action :redirect_to_login
   def index
   end
 

--- a/app/controllers/mypages_controller.rb
+++ b/app/controllers/mypages_controller.rb
@@ -1,6 +1,7 @@
 class MypagesController < ApplicationController
   include ApplicationHelper
   before_action :redirect_to_login
+
   def index
   end
 
@@ -11,11 +12,9 @@ class MypagesController < ApplicationController
   end
 
   def addcard
-    
   end
 
   def card_info
-    
   end
 
   def personal_info

--- a/app/controllers/payments_controller.rb
+++ b/app/controllers/payments_controller.rb
@@ -2,6 +2,7 @@ class PaymentsController < ApplicationController
   require 'payjp'
   include PaymentsHelper
   include ApplicationHelper
+  before_action :redirect_to_root, only: [:new]
   before_action :redirect_to_login
 
   def index
@@ -53,5 +54,9 @@ class PaymentsController < ApplicationController
 
   def card_update_params
     params.require(:user_payment).permit(:card_id)
+  end
+
+  def redirect_to_root
+    redirect_to root_path unless session[:user_registration?]
   end
 end

--- a/app/controllers/payments_controller.rb
+++ b/app/controllers/payments_controller.rb
@@ -1,6 +1,8 @@
 class PaymentsController < ApplicationController
   require 'payjp'
   include PaymentsHelper
+  include ApplicationHelper
+  before_action :redirect_to_login
 
   def index
     @payment = UserPayment.where(user_id: current_user.id).first

--- a/app/controllers/payments_controller.rb
+++ b/app/controllers/payments_controller.rb
@@ -55,8 +55,4 @@ class PaymentsController < ApplicationController
   def card_update_params
     params.require(:user_payment).permit(:card_id)
   end
-
-  def redirect_to_root
-    redirect_to root_path unless session[:user_registration?]
-  end
 end

--- a/app/controllers/signups_controller.rb
+++ b/app/controllers/signups_controller.rb
@@ -1,5 +1,8 @@
 class SignupsController < ApplicationController
+  include ApplicationHelper
   before_action :redirect_to_root
+  before_action :time_out_redirect, except: [:time_out]
+
   def sms_authentication
   end
 
@@ -37,13 +40,30 @@ class SignupsController < ApplicationController
   end
 
   def complete
+    session_delete
+  end
+
+  def time_out
+    session_delete
+  end
+
+  private
+
   def redirect_to_root
     redirect_to root_path unless session[:user_registration?]
   end
+
+  def time_out_redirect
+    redirect_to action: 'time_out' if passed_time > 3600
+  end
+
+  def session_delete
     session.delete(:sns_credential?)
     session.delete(:user_name)
     session.delete(:user_email)
     session.delete(:sns_credential_token)
     session.delete(:sms_number)
+    session.delete(:user_registration?)
+    session.delete(:time)
   end
 end

--- a/app/controllers/signups_controller.rb
+++ b/app/controllers/signups_controller.rb
@@ -49,10 +49,6 @@ class SignupsController < ApplicationController
 
   private
 
-  def redirect_to_root
-    redirect_to root_path unless session[:user_registration?]
-  end
-
   def time_out_redirect
     redirect_to action: 'time_out' if passed_time > 3600
   end

--- a/app/controllers/signups_controller.rb
+++ b/app/controllers/signups_controller.rb
@@ -1,4 +1,5 @@
 class SignupsController < ApplicationController
+  before_action :redirect_to_root
   def sms_authentication
   end
 
@@ -36,6 +37,9 @@ class SignupsController < ApplicationController
   end
 
   def complete
+  def redirect_to_root
+    redirect_to root_path unless session[:user_registration?]
+  end
     session.delete(:sns_credential?)
     session.delete(:user_name)
     session.delete(:user_email)

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 
 class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
+  include ApplicationHelper
   require 'securerandom'
+  require 'time'
   # You should configure your model like this:
   # devise :omniauthable, omniauth_providers: [:twitter]
 
@@ -49,6 +51,7 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
       sign_in_and_redirect @user, event: :authentication
     else
       session["devise.#{provider}_data"] = request.env["omniauth.auth"].except("extra")
+      set_time
       redirect_to new_user_registration_path
     end
   end
@@ -61,7 +64,7 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
   protected
 
   def after_sign_in_path_for(resource)
-    root_path
+    stored_location_for(resource)
   end
 
   # The path used when OmniAuth fails

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -60,10 +60,6 @@ class Users::RegistrationsController < Devise::RegistrationsController
     devise_parameter_sanitizer.permit(:sign_up, keys: [:name, :email, :password, :birthday, :last_name, :first_name, :last_name_kana, :first_name_kana])
   end
 
-  def redirect_to_root
-    redirect_to root_path unless session[:user_registration?]
-  end
-
   def time_out
     redirect_to time_out_signups_path if passed_time > 3600
   end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,15 +1,20 @@
 # frozen_string_literal: true
 
 class Users::RegistrationsController < Devise::RegistrationsController
+  include ApplicationHelper
   before_action :configure_sign_up_params, only: [:create]
   before_action :redirect_to_root, only: [:create]
+  before_action :time_out, only: [:create]
   # before_action :configure_account_update_params, only: [:update]
 
   # GET /resource/sign_up
   def new
+    session[:user_registration?] = true
     if session[:sns_credential?]
       @user_name = session[:user_name]
       @user_email = session[:user_email]
+    else
+      set_time
     end
     super
   end
@@ -57,6 +62,10 @@ class Users::RegistrationsController < Devise::RegistrationsController
 
   def redirect_to_root
     redirect_to root_path unless session[:user_registration?]
+  end
+
+  def time_out
+    redirect_to time_out_signups_path if passed_time > 3600
   end
   # If you have extra params to permit, append them to the sanitizer.
   # def configure_account_update_params

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -2,6 +2,7 @@
 
 class Users::RegistrationsController < Devise::RegistrationsController
   before_action :configure_sign_up_params, only: [:create]
+  before_action :redirect_to_root, only: [:create]
   # before_action :configure_account_update_params, only: [:update]
 
   # GET /resource/sign_up
@@ -54,6 +55,9 @@ class Users::RegistrationsController < Devise::RegistrationsController
     devise_parameter_sanitizer.permit(:sign_up, keys: [:name, :email, :password, :birthday, :last_name, :first_name, :last_name_kana, :first_name_kana])
   end
 
+  def redirect_to_root
+    redirect_to root_path unless session[:user_registration?]
+  end
   # If you have extra params to permit, append them to the sanitizer.
   # def configure_account_update_params
   #   devise_parameter_sanitizer.permit(:account_update, keys: [:name, :email, :password, :birthday, :last_name, :first_name, :last_name_kana, :first_name_kana])

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -21,7 +21,7 @@ class Users::SessionsController < Devise::SessionsController
   protected
 
   def after_sign_in_path_for(resource)
-    root_path
+    stored_location_for(resource) || root_path
   end 
 
   # If you have extra params to permit, append them to the sanitizer.

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,5 +1,4 @@
 class UsersController < ApplicationController
-
   def new
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,4 +1,5 @@
 module ApplicationHelper
+  require 'time'
   def redirect_to_login
     unless user_signed_in?
       redirect_to new_user_session_path
@@ -6,4 +7,15 @@ module ApplicationHelper
     end
   end
 
+  def set_time
+    t = Time.now.to_s
+    session[:time] = Time.parse(t).to_i
+  end
+
+  def passed_time
+    t = Time.now.to_s
+    time = Time.parse(t).to_i
+    pass_time = time - session[:time]
+    return pass_time
+  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,3 +1,9 @@
 module ApplicationHelper
+  def redirect_to_login
+    unless user_signed_in?
+      redirect_to new_user_session_path
+      flash.now[:alert] = 'ログインが必要です！'
+    end
+  end
 
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,10 +1,15 @@
 module ApplicationHelper
   require 'time'
+  
   def redirect_to_login
     unless user_signed_in?
       redirect_to new_user_session_path
       flash.now[:alert] = 'ログインが必要です！'
     end
+  end
+
+  def redirect_to_root
+    redirect_to root_path unless session[:user_registration?]
   end
 
   def set_time

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,12 +4,11 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable, :confirmable, :omniauthable, omniauth_providers: [:facebook, :google_oauth2]
 
-  has_one :user_address
-  has_one :user_identification
-  has_one :user_delivery
-  has_one :sns_credential
-  has_many :user_payments
-  has_many :likes
+  has_one :user_address, dependent: :destroy
+  has_one :user_delivery, dependent: :destroy
+  has_one :sns_credential, dependent: :destroy
+  has_many :user_payments, dependent: :destroy
+  has_many :likes, dependent: :destroy
   has_many :reports
   has_many :dealing_items
   has_many :bought_items

--- a/app/views/buy/show.html.haml
+++ b/app/views/buy/show.html.haml
@@ -1,6 +1,7 @@
 = render partial: "layouts/header"
 
 .buy
+  
   = form_with model: @item, url: buy_index_path, method: :post, id: "buy_form", local: true do |f|
     .buy__title
       購入内容の確認

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -3,7 +3,7 @@
   .login__panel
     .login__panel--no-content
       %p アカウントをお持ちでない方はこちら
-      = link_to "新規会員登録", "http://localhost:3000/users/sign_up", class: "blue"
+      = link_to "新規会員登録", new_user_path, class: "blue"
     .login__panel--form
       - resource_class.omniauth_providers.each_with_index do |provider, i|
         - if i == 0

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -1,5 +1,8 @@
 .wrapper
-  = render partial: 'homes/header'
+  - if user_signed_in?
+    = render partial: 'homes/header-login'
+  - else
+    = render partial: 'homes/header'
   .items-container
     %h1
       = @item.name

--- a/app/views/signups/time_out.html.haml
+++ b/app/views/signups/time_out.html.haml
@@ -1,0 +1,7 @@
+= render partial: "layouts/header"
+
+.buy
+  .buy__title
+    time_out: やり直してください。
+
+= render partial: "layouts/footer"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,7 +26,7 @@ Rails.application.routes.draw do
     get 'users/confirmation/new', to: 'users/confirmations#new', as: :new_user_confirmation
     post 'users/confirmation', to: 'users/confirmations#create'
     get 'users/confirmation', to: 'users/confirmations#show', as: :user_confirmation
-    end
+  end
 
   resources :signups do
     collection do
@@ -35,6 +35,7 @@ Rails.application.routes.draw do
       get :sms_confirmation
       post :sms_check
       get :complete
+      get :time_out
     end
   end
   resources :deliveries, only: [:new, :create, :show, :update]


### PR DESCRIPTION
## what
- ログインが必要なページに未ログインユーザーがアクセスした際にbefore_actionでログインページに飛ばすように設定（ApplicationHelper.redirect_to_login）
- ログインした際にログインする直前のページに移動するように設定
- ユーザー新規登録時に1時間以上経過するとタイムアウトと表示し、中止させる。
- リファクタリング

## why
- ログインが必要なページに未ログインのユーザーが侵入するのを防ぐため。
- フレンドリーフォワーディング機能はユーザーの利便性を高めるため。
- ユーザーが新規登録の途中で放置した際にタイムアウトを設定することで、セキュリティーを高める。
 