### PR TITLE
カタカナのバリデーションの追加

### DIFF
--- a/app/assets/stylesheets/likes.scss
+++ b/app/assets/stylesheets/likes.scss
@@ -1,3 +1,0 @@
-// Place all the styles related to the likes controller here.
-// They will automatically be included in application.css.
-// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -21,8 +21,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
 
   # POST /resource
   def create
-    @validation = User.validation?(params[:user])
-    if @validation
+    if User.validation?(params[:user])
       super
       @user = User.find_by(email: params[:user][:email])
       @sns_user = SnsCredential.find_by(token: session[:sns_credential_token])

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -21,11 +21,15 @@ class Users::RegistrationsController < Devise::RegistrationsController
 
   # POST /resource
   def create
-    super
-    @user = User.find_by(email: params[:user][:email])
-    @sns_user = SnsCredential.find_by(token: session[:sns_credential_token])
-    if session[:sns_credential?] && session[:sns_credential_token] == @sns_user.token
-      @sns_user.update(user_id: @user.id)
+    @validation = User.validation?(params[:user])
+    if @validation
+      super
+      @user = User.find_by(email: params[:user][:email])
+      @sns_user = SnsCredential.find_by(token: session[:sns_credential_token])
+      elsif session[:sns_credential?] && session[:sns_credential_token] == @sns_user.token
+        @sns_user.update(user_id: @user.id)
+    else
+      render :new
     end
   end
 

--- a/app/helpers/homes_helper.rb
+++ b/app/helpers/homes_helper.rb
@@ -1,2 +1,0 @@
-module HomesHelper
-end

--- a/app/models/dealing.rb
+++ b/app/models/dealing.rb
@@ -11,8 +11,8 @@ class Dealing < ApplicationRecord
   validates :dealing_status_id, presence: true
   validates :last_name, presence: true, length: { maximum: 20 }
   validates :first_name, presence: true, length: { maximum: 20 }
-  validates :last_name_kana, presence: true, length: { maximum: 20 }
-  validates :first_name_kana, presence: true, length: { maximum: 20 }
+  validates :last_name_kana, presence: true, length: { maximum: 20 }, format: { with: /\A[\p{katakana}　ー－&&[^ -~｡-ﾟ]]+\z/ }
+  validates :first_name_kana, presence: true, length: { maximum: 20 }, format: { with: /\A[\p{katakana}　ー－&&[^ -~｡-ﾟ]]+\z/ }
   validates :postal_number, presence: true, format: { with: /\A[0-9]{7}\z/ }
   validates :prefecture_id, presence: true
   validates :city, presence: true, length: { maximum: 25 }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -38,4 +38,10 @@ class User < ApplicationRecord
       return false
     end
   end
+
+  def self.validation?(params)
+    user_attr = {name: params[:name], email: params[:email], password: params[:password], last_name: params[:last_name], last_name_kana: params[:last_name_kana], first_name: params[:first_name], first_name_kana: params[:first_name_kana]}
+    user = User.new(user_attr)
+    return user.valid?
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -19,8 +19,8 @@ class User < ApplicationRecord
   validates :email, presence: true, uniqueness: true, length: { maximum: 255 }, format: { with: /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i }
   validates :last_name, presence: true, length: { maximum: 20 }
   validates :first_name, presence: true, length: { maximum: 20 }
-  validates :last_name_kana, presence: true, length: { maximum: 20 }
-  validates :first_name_kana, presence: true, length: { maximum: 20 }
+  validates :last_name_kana, presence: true, length: { maximum: 20 }, format: { with: /\A[\p{katakana}　ー－&&[^ -~｡-ﾟ]]+\z/, message: "全角カタカナのみで入力して下さい" }
+  validates :first_name_kana, presence: true, length: { maximum: 20 }, format: { with: /\A[\p{katakana}　ー－&&[^ -~｡-ﾟ]]+\z/, message: "全角カタカナのみで入力して下さい" }
   validates :mobile_phone_number, format: { with: /\A[0-9]{10}\z/ }
   validates :birthday, presence: true
   validates :profile, length: { maximum: 1000 }

--- a/app/models/user_delivery.rb
+++ b/app/models/user_delivery.rb
@@ -6,8 +6,8 @@ class UserDelivery < ApplicationRecord
   validates :user_id, presence: true
   validates :last_name, presence: true, length: { maximum: 20 }
   validates :first_name, presence: true, length: { maximum: 20 }
-  validates :last_name_kana, presence: true, length: { maximum: 20 }
-  validates :first_name_kana, presence: true, length: { maximum: 20 }
+  validates :last_name_kana, presence: true, length: { maximum: 20 }, format: { with: /\A[\p{katakana}　ー－&&[^ -~｡-ﾟ]]+\z/, message: "全角カタカナのみで入力して下さい" }
+  validates :first_name_kana, presence: true, length: { maximum: 20 }, format: { with: /\A[\p{katakana}　ー－&&[^ -~｡-ﾟ]]+\z/, message: "全角カタカナのみで入力して下さい" }
   validates :postal_number, presence: true, format: { with: /\A[0-9]{7}\z/ }
   validates :prefecture_id, presence: true
   validates :city, presence: true, length: { maximum: 25 }

--- a/app/views/homes/index.html.haml
+++ b/app/views/homes/index.html.haml
@@ -1,4 +1,0 @@
-.wrapper
-  = render partial: 'homes/header'
-  = render partial: 'homes/contents'
-  = render partial: 'homes/footer'

--- a/spec/models/user_delivery_spec.rb
+++ b/spec/models/user_delivery_spec.rb
@@ -105,6 +105,18 @@ RSpec.describe UserDelivery, type: :model do
         expect(test_delivery.errors[:first_name_kana]).to include("is too long (maximum is 20 characters)")
       end
 
+      it "is invalid with a first_name_kana which is not written by katakana" do
+        test_delivery.first_name_kana = "あいうえおかきくけこさしすせそたちつてと"
+        subject
+        expect(test_delivery.errors[:first_name_kana]).to include("全角カタカナのみで入力して下さい")
+      end
+
+      it "is invalid with a last_name_kana which is not written by katakana" do
+        test_delivery.last_name_kana = "あいうえおかきくけこさしすせそたちつてと"
+        subject
+        expect(test_delivery.errors[:last_name_kana]).to include("全角カタカナのみで入力して下さい")
+      end
+
       it "is invalid with a postal_number which is less than 6 characters" do
         test_delivery.postal_number = "123456"
         subject

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -18,99 +18,99 @@ RSpec.describe User, type: :model do
     context "cannot save" do
       it "is invalid without name" do
         test_user.name = nil
-        test_user.valid?
+        subject
         expect(test_user.errors[:name]).to include("can't be blank")
       end
 
       it "is invalid without email" do
         test_user.email = nil
-        test_user.valid?
+        subject
         expect(test_user.errors[:email]).to include("can't be blank")
       end
 
       it "is invalid without password" do
         test_user.password = nil
-        test_user.valid?
+        subject
         expect(test_user.errors[:password]).to include("can't be blank")
       end
 
       it "is invalid without last_name" do
         test_user.last_name = nil
-        test_user.valid?
+        subject
         expect(test_user.errors[:last_name]).to include("can't be blank")
       end
 
       it "is invalid without first_name" do
         test_user.first_name = nil
-        test_user.valid?
+        subject
         expect(test_user.errors[:first_name]).to include("can't be blank")
       end
 
       it "is invalid without last_name_kana" do
         test_user.last_name_kana = nil
-        test_user.valid?
+        subject
         expect(test_user.errors[:last_name_kana]).to include("can't be blank")
       end
 
       it "is invalid without first_name_kana" do
         test_user.first_name_kana = nil
-        test_user.valid?
+        subject
         expect(test_user.errors[:first_name_kana]).to include("can't be blank")
       end
 
       it "is invalid without birthday" do
         test_user.birthday = nil
-        test_user.valid?
+        subject
         expect(test_user.errors[:birthday]).to include("can't be blank")
       end
 
       it "is invalid with a duplicated name" do
         user = create(:user)
         test_user.name = user.name
-        test_user.valid?
+        subject
         expect(test_user.errors[:name]).to include("has already been taken")
       end
 
       it "is invalid with a duplicated email" do
         user = create(:user)
         test_user.email = user.email
-        test_user.valid?
+        subject
         expect(test_user.errors[:email]).to include("has already been taken")
       end
 
       it "is invalid with a name which is more than 21 characters" do
         test_user.name = "aaaaaaaaaabbbbbbbbbbc"
-        test_user.valid?
+        subject
         expect(test_user.errors[:name]).to include("is too long (maximum is 20 characters)")
       end
 
       it "is invalid with a password which is less than 5 characters" do
         test_user.password = 12345
-        test_user.valid?
+        subject
         expect(test_user.errors[:password]).to include("is too short (minimum is 6 characters)")
       end
 
       it "is invalid with a last_name which is more than 21 characters" do
         test_user.last_name = "あいうえおかきくけこさしすせそたちつてとな"
-        test_user.valid?
+        subject
         expect(test_user.errors[:last_name]).to include("is too long (maximum is 20 characters)")
       end
 
       it "is invalid with a first_name which is more than 21 characters" do
         test_user.first_name = "あいうえおかきくけこさしすせそたちつてとな"
-        test_user.valid?
+        subject
         expect(test_user.errors[:first_name]).to include("is too long (maximum is 20 characters)")
       end
 
       it "is invalid with a last_name_kana which is more than 21 characters" do
         test_user.last_name_kana = "アイウエオカキクケコサシスセソタチツテトナ"
-        test_user.valid?
+        subject
         expect(test_user.errors[:last_name_kana]).to include("is too long (maximum is 20 characters)")
       end
 
       it "is invalid with a first_name_kana which is more than 21 characters" do
         test_user.first_name_kana = "アイウエオカキクケコサシスセソタチツテトナ"
-        test_user.valid?
+        subject
         expect(test_user.errors[:first_name_kana]).to include("is too long (maximum is 20 characters)")
       end
 
@@ -128,19 +128,19 @@ RSpec.describe User, type: :model do
 
       it "is invalid with a mobile phone number which is less than 9 digits" do
         test_user.mobile_phone_number = 123456789
-        test_user.valid?
+        subject
         expect(test_user.errors[:mobile_phone_number]).to include("is invalid")
       end
 
       it "is invalid with a mobile phone number which is more than 11 digits" do
         test_user.mobile_phone_number = 12345678901
-        test_user.valid?
+        subject
         expect(test_user.errors[:mobile_phone_number]).to include("is invalid")
       end
 
       it "is invalid with a mobile phone number which includes hyphen" do
         test_user.mobile_phone_number = "090-1234-5678"
-        test_user.valid?
+        subject
         expect(test_user.errors[:mobile_phone_number]).not_to match(/\A[0-9]{10}\z/)
       end
     end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -114,6 +114,18 @@ RSpec.describe User, type: :model do
         expect(test_user.errors[:first_name_kana]).to include("is too long (maximum is 20 characters)")
       end
 
+      it "is invalid with a first_name_kana which is not written by katakana" do
+        test_user.first_name_kana = "あいうえおかきくけこさしすせそたちつてと"
+        subject
+        expect(test_user.errors[:first_name_kana]).to include("全角カタカナのみで入力して下さい")
+      end
+
+      it "is invalid with a last_name_kana which is not written by katakana" do
+        test_user.last_name_kana = "あいうえおかきくけこさしすせそたちつてと"
+        subject
+        expect(test_user.errors[:last_name_kana]).to include("全角カタカナのみで入力して下さい")
+      end
+
       it "is invalid with a mobile phone number which is less than 9 digits" do
         test_user.mobile_phone_number = 123456789
         test_user.valid?


### PR DESCRIPTION
## what
- カタカナのバリデーションを追加
- バリデーションが通らない時にregistrations_controllerでページ遷移しないようにクラスメソッドを用いて設定

## why
カタカナで保存されるべきフォームデータのため