### PR TITLE
fix-images

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -64,8 +64,8 @@ class ItemsController < ApplicationController
   def update
     item_update_subcategory
     @item = Item.find(params[:id])
-    if register_images[0] == item_images.length 
-      respond_to do |format| 
+    if register_images[0] == item_images.length || item_images.length == @item.images.length
+      respond_to do |format|
         format.js { render alert_image }
       end
     else
@@ -155,8 +155,6 @@ class ItemsController < ApplicationController
 
   def register_images
     register_ids = params.required(:item)[:register_images].split.map(&:to_i)
-    register_ids = 1 if register_ids[0] == nil
-    return register_ids
   end
 
   def item_params

--- a/app/views/items/edit.html.haml
+++ b/app/views/items/edit.html.haml
@@ -18,7 +18,7 @@
               = image_tag image.image.url, {class: "sell__image"}
             .sell__image_btn--edit{id: "#{i}_edit"}
               編集
-            .sell__image_btn--edit.current_image{id: i}
+            .sell__image_btn--delete.current_image{id: i}
               削除
       .sell__upload--drop_box#dropbox
         .sell__upload--text


### PR DESCRIPTION
画像が複数枚登録されているときに画像を保存されたすべて削除すると一部の枚数のときエラーが出ない問題を解決